### PR TITLE
Create essential GitHub templates (i.e. bug, pull request, ...)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,40 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug description
+      placeholder: A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Describe steps to reproduce the behaviour.
+      placeholder: 1. Go to '...'
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behaviour
+    attributes:
+      label: Expected behaviour
+      description: Describe the behaviour you were expecting.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Submit new feature request 
+title: "[FEAT]: "
+labels: ["feature"]
+body:
+  - type: textarea
+    id: fr-context
+    attributes:
+      label: Feature request context & motivation
+      description: Describe the context and motivation for the creation of this feature request.
+    validations:
+      required: true
+  - type: textarea
+    id: fr-description
+    attributes:
+      label: Feature request description
+      description: Describe in detail your feature request.
+    validations:
+      required: true
+  - type: textarea
+    id: fr-alternatives
+    attributes:
+      label: Feature request alternatives
+      description: Describe the alternatives you considered.
+    validations:
+      required: false
+  - type: textarea
+    id: fr-additionalinfo
+    attributes:
+      label: Additional information
+      description: Provide additional information you considered relevant for this feature request.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,46 @@
+name: Task
+description: Submit new Task
+labels: ["task"]
+body:
+  - type: textarea
+    id: task-aim
+    attributes:
+      label: Aim
+      description: Describe the aim and motivation for the creation of this task.
+    validations:
+      required: true
+  - type: textarea
+    id: task-assumption
+    attributes:
+      label: Assumptions
+      description: Provide a list of assumptions that must be considered for this task.
+    validations:
+      required: true
+  - type: textarea
+    id: task-acceptancecriteria
+    attributes:
+      label: Acceptance criteria
+      description: Describe a list of acceptance criteria for this task.
+    validations:
+      required: true
+  - type: textarea
+    id: task-risks
+    attributes:
+      label: Risks
+      description: Provide a list of risks that should be considered for this task.
+    validations:
+      required: true
+  - type: textarea
+    id: task-dependencies
+    attributes:
+      label: Dependencies
+      description: Indicate any dependencies that could block the execution of this task
+    validations:
+      required: false
+  - type: textarea
+    id: task-references
+    attributes:
+      label: References
+      description: Provide a list of references that should be used to assure the correct execution of this task.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+## Description
+
+Please include a summary of the changes proposed by this pull request (PR). Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+
+## Related issues
+
+Please indicate the issues affected by this PR using the correct Github [syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) and the correct keywords.
+
+Ex:  
+fix #1  
+closes #3
+
+## How has this been tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
+
+- [ ] Test A
+- [ ] Test B
+
+**Test configuration**:
+* Firmware version:
+* Hardware:
+* Toolchain:
+* SDK:
+
+## Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] I have checked my code and corrected any misspellings


### PR DESCRIPTION
## Description

Add various GitHub templates to ease developer's life when manifesting a bug report, creating a new pull requests or opening a new issue, for instance.

## Related issues

- None

## How has this been tested?

Tests were conducted on the GitHub interface.

## Checklist:

- [x] I have performed a self-review of my own code